### PR TITLE
GET metrics not PUT metrics

### DIFF
--- a/docs/ZincSearch/API/metrics.md
+++ b/docs/ZincSearch/API/metrics.md
@@ -11,5 +11,5 @@ You should set environment `ZINC_PROMETHEUS_ENABLE=true` enable prometheus metri
 ## Request
 
 e.g. 
-PUT http://localhost:4080/metrics
+GET http://localhost:4080/metrics
 


### PR DESCRIPTION
metrics endpoints for zincsearch should be GET not PUT method
![image](https://user-images.githubusercontent.com/6478745/223013343-4c09ddd5-9f5d-46b9-9e32-e06aeec2999c.png)
